### PR TITLE
Display logger's metadata for selected path

### DIFF
--- a/lib/membrane_dashboard_web/live/components/elements_select.ex
+++ b/lib/membrane_dashboard_web/live/components/elements_select.ex
@@ -6,10 +6,38 @@ defmodule Membrane.DashboardWeb.Live.Components.ElementsSelect do
 
   use Membrane.DashboardWeb, :live_component
 
+  import Ecto.Query
   import Membrane.DashboardWeb.Live.Helpers, only: [info_header: 1, arrow_down_icon: 1]
+
+  alias Membrane.Dashboard.Repo
 
   @impl true
   def mount(socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    path = Enum.join(assigns.active_path, "/")
+
+    metadata =
+      "elements"
+      |> where([el], el.path == ^path)
+      |> select(fragment("metadata->'log_metadata'"))
+      |> Repo.one()
+      |> case do
+        nil ->
+          %{}
+
+        metadata ->
+          Map.drop(metadata, ["mb_prefix", "parent_path"])
+      end
+
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(:metadata, metadata)
+
     {:ok, socket}
   end
 
@@ -22,30 +50,51 @@ defmodule Membrane.DashboardWeb.Live.Components.ElementsSelect do
         tooltip="You may want to filter charts to a subset of elements or a single particular element, you can do so by selecting elements' path"
       />
       <%= if length(@active_path) > 0 do %>
-        <div class="flex flex-col justify-center bg-secondary rounded-xl w-fit p-3">
-          <%= for element <- Enum.intersperse(@active_path, :icon) do %>
-            <%= if element == :icon do %>
-              <div class="flex justify-center items-center p-2">
-                <.arrow_down_icon />
-              </div>
-            <% else %>
-              <div class="text-white rounded-lg bg-primary border border-gray-300/25 p-3 mb-2">
-                <%= element %>
+        <div class="flex bg-secondary rounded-xl w-fit p-3">
+          <div class="flex flex-col justify-center ">
+            <span class="font-bold text-white text-lg mb-3">Path</span>
+            <%= for element <- Enum.intersperse(@active_path, :icon) do %>
+              <%= if element == :icon do %>
+                <div class="flex justify-center items-center p-2">
+                  <.arrow_down_icon />
+                </div>
+              <% else %>
+                <div class="text-white rounded-lg bg-primary border border-gray-300/25 p-3 mb-2">
+                  <%= element %>
+                </div>
+              <% end %>
+            <% end %>
+
+            <div class="flex justify-end">
+              <button
+                type="button"
+                disabled={@disabled}
+                class="danger-button m-2"
+                phx-click="reset-active-elements"
+                phx-target={@myself}
+              >
+                Reset
+              </button>
+            </div>
+          </div>
+
+          <div class="flex flex-col ml-8">
+            <span class="font-bold text-white text-lg mb-3">Logger's metadata (key-value pairs)</span>
+            <%= if @metadata == %{} do %>
+              <span class="text-white mb-3">Not metadata found</span>
+            <% end %>
+            <%= for {key, value} <- @metadata do %>
+
+              <div class="flex items-center overflow-hidden text-white rounded-lg bg-primary border border-gray-300/25 mb-2">
+                <div class="p-3 bg-secondary font-bold">
+                  <%= key %>
+                </div>
+                <div class="p-3">
+                    <%= value %>
+                </div>
               </div>
             <% end %>
-          <% end %>
-
-          <div class="flex justify-end">
-            <button
-              type="button"
-              disabled={@disabled}
-              class="danger-button m-2"
-              phx-click="reset-active-elements"
-              phx-target={@myself}
-            >
-              Reset
-            </button>
-          <div>
+          </div>
         </div>
       <% else %>
         <div class="flex items-center bg-secondary rounded-xl p-3 description">


### PR DESCRIPTION
This PR introduces display of logger's metadata when an element's path gets selected by the user.
Closes #6 

![image](https://user-images.githubusercontent.com/34857220/147946621-1c9b32c5-ea98-4390-a5d5-09242ab85856.png)

When no metadata is present for an element.
![image](https://user-images.githubusercontent.com/34857220/147946738-bfa1ad98-df17-4cca-bc18-5f34d0da780b.png)



Blocked by https://github.com/membraneframework/membrane_core/pull/376