### PR TITLE
Fixed charts update gradually reducing number of measurements

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -31,7 +31,7 @@
   .description {
     @apply text-lg text-white;
   }
-  
+
   .error {
     @apply text-lg text-red-500;
   }

--- a/assets/src/hooks/ChartsHook.ts
+++ b/assets/src/hooks/ChartsHook.ts
@@ -95,8 +95,8 @@ const ChartsHook = {
         !!chart,
         "Chart should be present during update but is not..."
       );
-      
-      // if the number of series has changed it means that 
+
+      // if the number of series has changed it means that
       // either new series have been added or removed
       // in such case just clear the chart and add all the series from the
       // chartData
@@ -109,10 +109,6 @@ const ChartsHook = {
         for (let i = 0; i < chartData.series.length; i++) {
           const series = chartData.series[i];
 
-          series.value = (_, rawValue) => {
-            return formatter(new Date(rawValue * 1000)) + `    -> ${rawValue}`;
-          };
-
           const color = randomColor();
           series.stroke = color;
           series.spanGaps = true;
@@ -121,6 +117,10 @@ const ChartsHook = {
           };
           chart.addSeries(series);
         }
+
+        chart.series[0].value = (_, rawValue) => {
+          return formatter(new Date(rawValue * 1000)) + `    -> ${rawValue}`;
+        };
       }
 
       // given series is empty therefore hide the charts

--- a/lib/membrane_dashboard/charts/chart_data_frame.ex
+++ b/lib/membrane_dashboard/charts/chart_data_frame.ex
@@ -144,7 +144,7 @@ defmodule Membrane.Dashboard.Charts.ChartDataFrame do
       df1
       |> DataFrame.select(MapSet.to_list(series_to_drop), :drop)
       # we need to drop leading values from rows
-      |> DataFrame.slice(new_series_n, old_series_n - new_series_n - back_shift)
+      |> DataFrame.slice(new_series_n - back_shift - 1, old_series_n - new_series_n)
       |> DataFrame.mutate(new_series |> Map.new(&{&1, old_series_nils}))
 
     df2 = DataFrame.mutate(df2, old_series |> Map.new(&{&1, new_series_nils}))

--- a/lib/membrane_dashboard_web/live/components/elements_select.ex
+++ b/lib/membrane_dashboard_web/live/components/elements_select.ex
@@ -22,7 +22,7 @@ defmodule Membrane.DashboardWeb.Live.Components.ElementsSelect do
 
     metadata =
       "elements"
-      |> where([el], el.path == ^path)
+      |> where([el], el.path == ^path and fragment("metadata->'log_metadata' is not null"))
       |> select(fragment("metadata->'log_metadata'"))
       |> Repo.one()
       |> case do


### PR DESCRIPTION
This PR fixes a situation when after each update chart would lose a certain number of measurements caused by backshifting results necessary for reloading unsaved measurements. Additionaly fixed a bug where mergin data frames would crash due to invalid shapes.